### PR TITLE
Adjusting API references to work with Kubernetes v 1.16.

### DIFF
--- a/divvycloud/templates/application.yaml
+++ b/divvycloud/templates/application.yaml
@@ -84,7 +84,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ .Release.Name }}
   componentKinds:
-  - group: apps/v1beta2
+  - group: apps/v1
     kind: Deployment
   - group: batch/v1
     kind: Job

--- a/divvycloud/templates/interfaceserver.yaml
+++ b/divvycloud/templates/interfaceserver.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "divvycloud.name" . }}-interfaceserver

--- a/divvycloud/templates/mysql.yaml
+++ b/divvycloud/templates/mysql.yaml
@@ -18,7 +18,7 @@ spec:
 
 {{ if eq .Values.useExternalDb false }}
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "divvycloud.name" . }}-mysql

--- a/divvycloud/templates/redis.yaml
+++ b/divvycloud/templates/redis.yaml
@@ -1,6 +1,6 @@
 ---
 {{- if eq .Values.useExternalRedis false }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/divvycloud/templates/scheduler.yaml
+++ b/divvycloud/templates/scheduler.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "divvycloud.name" . }}-scheduler

--- a/divvycloud/templates/sql_proxy.yaml
+++ b/divvycloud/templates/sql_proxy.yaml
@@ -1,7 +1,7 @@
 
 {{ if .Values.cloudSQLInstanceName }}
 {{- $instances := (printf "\"-instances=%s=tcp:0.0.0.0:3306\""  (.Values.cloudSQLInstanceName)) -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "divvycloud.name" . }}-mysql-proxy

--- a/divvycloud/templates/workers.yaml
+++ b/divvycloud/templates/workers.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "divvycloud.name" . }}-worker


### PR DESCRIPTION
Switching apps/v1beta2 to apps/v1 to accommodate Kubernetes merging and deprecating apps/v1beta2 api references.

[Deprecation Notice for Version 1.16](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)